### PR TITLE
Remove naming of new Datatokens internally. Name and symbol now has t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const dtFactory = new web3.eth.Contract(
 
 // create new datatoken
 const tx = await dtFactory.methods
-               .createToken('https://123example.com')
+               .createToken('https://123example.com', "my datatoken", "DT", web3.utils.toWei('1000000'))
                .send()
 let tokenAddress = null
 try {

--- a/contracts/DTFactory.sol
+++ b/contracts/DTFactory.sol
@@ -21,9 +21,6 @@ contract DTFactory is Deployer, Converter {
     address private tokenTemplate;
     address private communityFeeCollector;
     uint256 private currentTokenCount = 1;
-    // cap has max uint256 (2^256 -1)
-    uint256
-    private constant cap = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
     event TokenCreated(
         address indexed newTokenAddress,
@@ -67,17 +64,24 @@ contract DTFactory is Deployer, Converter {
     function createToken(
         string memory blob,
         string memory name,
-        string memory symbol
+        string memory symbol,
+        uint256 cap
     )
         public
         returns (address token)
     {
+        require(
+            cap > 0,
+            '0 cap is not allowed.'
+        );
+
         token = deploy(tokenTemplate);
 
         require(
             token != address(0),
             'DTFactory: Failed to perform minimal deploy of a new token'
         );
+
 
         IERC20Template tokenInstance = IERC20Template(token);
         tokenInstance.initialize(

--- a/docs/contracts/DTFactory.md
+++ b/docs/contracts/DTFactory.md
@@ -17,7 +17,7 @@ constructor
 Called on contract deployment. Could not be called with zero address parameters.
 
 
-### `createToken(string blob, string name, string symbol) → address token` (public)
+### `createToken(string blob, string name, string symbol, uint256 cap) → address token` (public)
 
 
 

--- a/test/unit/datatokens/DataTokenTemplate.Test.js
+++ b/test/unit/datatokens/DataTokenTemplate.Test.js
@@ -42,7 +42,7 @@ contract('DataTokenTemplate', async (accounts) => {
             communityFeeCollector
         )
         blob = 'https://example.com/dataset-1'
-        const trxReceipt = await factory.createToken(blob, 'DT1', 'DT1')
+        const trxReceipt = await factory.createToken(blob, 'DT1', 'DT1', web3.utils.toWei('1000000'))
         const TokenCreatedEventArgs = testUtils.getEventArgsFromTx(trxReceipt, 'TokenCreated')
         tokenAddress = TokenCreatedEventArgs.newTokenAddress
         token = await Token.at(tokenAddress)

--- a/test/unit/factory/Factory.Test.js
+++ b/test/unit/factory/Factory.Test.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-/* global artifacts, contract, it, beforeEach, assert */
+/* global artifacts, contract, web3, it, beforeEach, assert */
 
 const DTFactory = artifacts.require('DTFactory')
 const Template = artifacts.require('DataTokenTemplate')
@@ -27,7 +27,7 @@ contract('Factory test', async accounts => {
     it('should create a token and check that it is not a zero address', async () => {
         truffleAssert.passes(
             result = await factory.createToken(
-                blob, '99-Datatoken', '99-Datatoken',
+                blob, '99-Datatoken', '99-Datatoken', web3.utils.toWei('1000000'),
                 {
                     from: minter
                 }

--- a/test/unit/fixedRate/FixedRateExchange.Test.js
+++ b/test/unit/fixedRate/FixedRateExchange.Test.js
@@ -50,14 +50,14 @@ contract('FixedRateExchange', async (accounts) => {
         fixedRateExchange = await FixedRateExchange.new()
         factory = await DTFactory.new(template.address, communityFeeCollector)
         // Bob creates basetokens
-        let trxReceipt = await factory.createToken(blob, 'DT1', 'DT1', {
+        let trxReceipt = await factory.createToken(blob, 'DT1', 'DT1', web3.utils.toWei('1000000'), {
             from: bob
         })
         let TokenCreatedEventArgs = testUtils.getEventArgsFromTx(trxReceipt, 'TokenCreated')
         tokenAddress = TokenCreatedEventArgs.newTokenAddress
         basetoken = await Token.at(tokenAddress)
         // ALice creates datatokens
-        trxReceipt = await factory.createToken(blob, 'DT2', 'DT2', {
+        trxReceipt = await factory.createToken(blob, 'DT2', 'DT2', web3.utils.toWei('1000000'), {
             from: alice
         })
         TokenCreatedEventArgs = testUtils.getEventArgsFromTx(trxReceipt, 'TokenCreated')


### PR DESCRIPTION
…o be supplied to the `createToken` call.

https://github.com/oceanprotocol/ocean-contracts/issues/174