### PR TITLE
Add consumer to startOrder

### DIFF
--- a/contracts/templates/DataTokenTemplate.sol
+++ b/contracts/templates/DataTokenTemplate.sol
@@ -31,6 +31,7 @@ contract DataTokenTemplate is IERC20Template, ERC20 {
     uint256 public constant BASE_MARKET_FEE_PERCENTAGE = BASE / 1000;
 
     event OrderStarted(
+            address indexed consumer, 
             uint256 amount, 
             uint256 serviceId, 
             uint256 startedAt,
@@ -237,6 +238,7 @@ contract DataTokenTemplate is IERC20Template, ERC20 {
         transfer(_minter, amount.sub(totalFee));
 
         emit OrderStarted(
+            msg.sender,
             amount,
             serviceId,
             block.number,


### PR DESCRIPTION
`DataTokenTemplate.startOrder` emits the `OrderStarted` event. This function is triggered by the consumer. 
Unfortunately, the consumer address is not included in the `OrderStarted` event's parameters which makes it harder to get all orders of a specific user.

The task here is to add the sender address to the `OrderStarted` event params and make sure it is `indexed`.