### PR TITLE
Add files for building and publishing PyPi package

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,38 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Create __init__.py files
+      run: find artifacts -type d -exec touch '{}'/__init__.py ';'
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include artifacts *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,29 @@
+[metadata]
+name = ocean-contracts
+version = 1.0.0a1
+author = leucothia
+author_email = devops@oceanprotocol.com
+description =  🐳 Ocean Protocol L1 - v4
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/oceanprotocol/contracts
+project_urls =
+    Bug Tracker = https://github.com/oceanprotocol/contracts/issues
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Natural Language :: English
+    Programming Language :: Python :: 3.6
+keywords = ocean-contracts
+
+[options]
+package_dir =
+    =artifacts
+packages = find:
+python_requires = >=3.6
+include_package_data = True
+zip_safe=False
+
+[options.packages.find]
+where = artifacts


### PR DESCRIPTION
Towards #348

Changes proposed in this PR:

- Add files needed for building and publishing PyPi package on release
  - `pyproject.toml` is needed for the `python -m build` command to work
  - `setup.cfg` defines the PyPi metadata
  - `MANIFEST.in` specifies the non-python files to include in the package
  - `.github/workflows/python-publish.yml` defines the workflow trigger and steps