### PR TITLE
add metadata hash to erc721

### DIFF
--- a/contracts/templates/ERC721Template.sol
+++ b/contracts/templates/ERC721Template.sol
@@ -48,7 +48,7 @@ contract ERC721Template is
         string decryptorUrl,
         bytes flags,
         bytes data,
-        string metaDataDecryptorAddress,
+        bytes metaDataHash,
         uint256 timestamp,
         uint256 blockNumber
     );
@@ -58,7 +58,7 @@ contract ERC721Template is
         string decryptorUrl,
         bytes flags,
         bytes data,
-        string metaDataDecryptorAddress,
+        bytes metaDataHash,
         uint256 timestamp,
         uint256 blockNumber
     );
@@ -155,7 +155,7 @@ contract ERC721Template is
      */
     function setMetaData(uint8 _metaDataState, string calldata _metaDataDecryptorUrl
         , string calldata _metaDataDecryptorAddress, bytes calldata flags, 
-        bytes calldata data) external {
+        bytes calldata data,bytes calldata _metaDataHash) external {
         require(
             permissions[msg.sender].updateMetadata == true,
             "ERC721Template: NOT METADATA_ROLE"
@@ -165,7 +165,7 @@ contract ERC721Template is
         metaDataDecryptorAddress = _metaDataDecryptorAddress;
         if(hasMetaData == false){
             emit MetadataCreated(msg.sender, _metaDataState, _metaDataDecryptorUrl,
-            flags, data, _metaDataDecryptorAddress,
+            flags, data, _metaDataHash, 
             /* solium-disable-next-line */
             block.timestamp,
             block.number);
@@ -173,14 +173,14 @@ contract ERC721Template is
         }
         else
             emit MetadataUpdated(msg.sender, metaDataState, _metaDataDecryptorUrl,
-            flags, data, _metaDataDecryptorAddress,
+            flags, data, _metaDataHash,
             /* solium-disable-next-line */
             block.timestamp,
             block.number);
     }
 
     /**
-     * @dev getMetaDataDecryptorUrl
+     * @dev getMetaData
      *      Returns metaDataState, metaDataDecryptorUrl, metaDataDecryptorAddress
      */
     function getMetaData() external view returns (string memory, string memory, uint8, bool){

--- a/test/unit/datatokens/ERC721Template.test.js
+++ b/test/unit/datatokens/ERC721Template.test.js
@@ -102,6 +102,7 @@ describe("ERC721Template", () => {
     [owner, reciever, user2, user3,user4, user5, user6, provider, opfCollector, marketFeeCollector] = await ethers.getSigners();
 
     data = web3.utils.asciiToHex(constants.blob[0]);
+    dataHash = web3.utils.asciiToHex(constants.blob[0]);
     flags = web3.utils.asciiToHex(constants.blob[0]);
 
  // DEPLOY ROUTER, SETTING OWNER
@@ -216,7 +217,7 @@ describe("ERC721Template", () => {
   it("#updateMetadata - should not be allowed to update the metadata if NOT in MetadataList", async () => {
     assert((await tokenERC721.getPermissions(user6.address)).updateMetadata == false)
     await expectRevert(
-      tokenERC721.connect(user6).setMetaData(metaDataState, metaDataDecryptorUrl, metaDataDecryptorAddress, flags, data),
+      tokenERC721.connect(user6).setMetaData(metaDataState, metaDataDecryptorUrl, metaDataDecryptorAddress, flags, data, dataHash),
       "ERC721Template: NOT METADATA_ROLE"
     );
   });
@@ -227,7 +228,7 @@ describe("ERC721Template", () => {
     let metadataInfo = await tokenERC721.getMetaData()
     assert(metadataInfo[3] === false)
 
-    let tx = await tokenERC721.connect(user6).setMetaData(metaDataState, metaDataDecryptorUrl, metaDataDecryptorAddress, flags, data);
+    let tx = await tokenERC721.connect(user6).setMetaData(metaDataState, metaDataDecryptorUrl, metaDataDecryptorAddress, flags, data, dataHash);
     let txReceipt = await tx.wait();
    
     let event = getEventFromTx(txReceipt,'MetadataCreated')
@@ -240,7 +241,7 @@ describe("ERC721Template", () => {
     assert(metadataInfo[0] == metaDataDecryptorUrl);
 
     const metaDataDecryptorUrl2 = 'http://someurl';
-    tx = await tokenERC721.connect(user6).setMetaData(metaDataState, metaDataDecryptorUrl2, metaDataDecryptorAddress, flags, data);
+    tx = await tokenERC721.connect(user6).setMetaData(metaDataState, metaDataDecryptorUrl2, metaDataDecryptorAddress, flags, data, dataHash);
     txReceipt = await tx.wait();
     event = getEventFromTx(txReceipt,'MetadataUpdated')
     assert(event, "Cannot find MetadataUpdated event")
@@ -669,12 +670,12 @@ describe("ERC721Template", () => {
     );
 
     await expectRevert(
-      tokenERC721.connect(user6).setMetaData(metaDataState, metaDataDecryptorUrl, metaDataDecryptorAddress, flags, data),
+      tokenERC721.connect(user6).setMetaData(metaDataState, metaDataDecryptorUrl, metaDataDecryptorAddress, flags, data, dataHash),
       "ERC721Template: NOT METADATA_ROLE"
     );
     
 
-    await tokenERC721.connect(user2).setMetaData(metaDataState, metaDataDecryptorUrl, metaDataDecryptorAddress, flags, data);
+    await tokenERC721.connect(user2).setMetaData(metaDataState, metaDataDecryptorUrl, metaDataDecryptorAddress, flags, data, dataHash);
 
     let metadataInfo = await tokenERC721.getMetaData()
     assert(metadataInfo[3] === true)


### PR DESCRIPTION
Add metadata hash to ERC721.
Needed for aqua to check DDO integrity  (see https://github.com/oceanprotocol/docs/blob/feature/ddo_v4/content/concepts/did-ddo.md)