### PR TITLE
Feature/small refactors

### DIFF
--- a/contracts/ERC721Factory.sol
+++ b/contracts/ERC721Factory.sol
@@ -43,7 +43,8 @@ contract ERC721Factory is Deployer, Ownable {
         address indexed templateAddress,
         string tokenName,
         address admin,
-        string symbol
+        string symbol,
+        string tokenURI
     );
 
        uint256 private currentTokenCount = 0;
@@ -110,7 +111,7 @@ contract ERC721Factory is Deployer, Ownable {
         string memory symbol,
         uint256 _templateIndex,
         address additionalERC20Deployer,
-        string memory baseURI
+        string memory tokenURI
     ) public returns (address token) {
         require(
             _templateIndex <= nftTemplateCount && _templateIndex != 0,
@@ -140,12 +141,12 @@ contract ERC721Factory is Deployer, Ownable {
                 symbol,
                 address(this),
                 additionalERC20Deployer,
-                baseURI
+                tokenURI
             ),
             "ERC721DTFactory: Unable to initialize token instance"
         );
 
-        emit NFTCreated(token, tokenTemplate.templateAddress, name, msg.sender, symbol);
+        emit NFTCreated(token, tokenTemplate.templateAddress, name, msg.sender, symbol, tokenURI);
         currentNFTCount += 1;
     }
     
@@ -517,7 +518,7 @@ contract ERC721Factory is Deployer, Ownable {
         string name;
         string symbol;
         uint256 templateIndex;
-        string baseURI;
+        string tokenURI;
     }
     struct ErcCreateData{
         uint256 templateIndex;
@@ -547,7 +548,7 @@ contract ERC721Factory is Deployer, Ownable {
             _NftCreateData.symbol,
             _NftCreateData.templateIndex,
             address(0),
-            _NftCreateData.baseURI);
+            _NftCreateData.tokenURI);
         erc20Address = _createToken(
             _ErcCreateData.templateIndex,
             _ErcCreateData.strings,
@@ -587,7 +588,7 @@ contract ERC721Factory is Deployer, Ownable {
             _NftCreateData.symbol,
             _NftCreateData.templateIndex,
             address(this),
-             _NftCreateData.baseURI);
+             _NftCreateData.tokenURI);
         erc20Address = _createToken(
             _ErcCreateData.templateIndex,
             _ErcCreateData.strings,
@@ -630,7 +631,7 @@ contract ERC721Factory is Deployer, Ownable {
             _NftCreateData.symbol,
             _NftCreateData.templateIndex,
             address(this),
-             _NftCreateData.baseURI);
+             _NftCreateData.tokenURI);
         erc20Address = _createToken(
             _ErcCreateData.templateIndex,
             _ErcCreateData.strings,
@@ -671,7 +672,7 @@ contract ERC721Factory is Deployer, Ownable {
             _NftCreateData.symbol,
             _NftCreateData.templateIndex,
             address(this),
-             _NftCreateData.baseURI);
+             _NftCreateData.tokenURI);
         erc20Address = _createToken(
             _ErcCreateData.templateIndex,
             _ErcCreateData.strings,

--- a/contracts/ERC721Factory.sol
+++ b/contracts/ERC721Factory.sol
@@ -42,7 +42,8 @@ contract ERC721Factory is Deployer, Ownable {
         address indexed newTokenAddress,
         address indexed templateAddress,
         string tokenName,
-        address admin
+        address admin,
+        string symbol
     );
 
        uint256 private currentTokenCount = 0;
@@ -144,7 +145,7 @@ contract ERC721Factory is Deployer, Ownable {
             "ERC721DTFactory: Unable to initialize token instance"
         );
 
-        emit NFTCreated(token, tokenTemplate.templateAddress, name, msg.sender);
+        emit NFTCreated(token, tokenTemplate.templateAddress, name, msg.sender, symbol);
         currentNFTCount += 1;
     }
     

--- a/contracts/ERC721Factory.sol
+++ b/contracts/ERC721Factory.sol
@@ -71,7 +71,13 @@ contract ERC721Factory is Deployer, Ownable {
 
 
     event NewFixedRate(bytes32 exchangeId, address owner);
-    event DispenserCreated(address indexed datatokenAddress);
+    event DispenserCreated(  // emited when a dispenser is created
+        address indexed datatokenAddress,
+        address indexed owner,
+        uint256 maxTokens,
+        uint256 maxBalance,
+        address allowedSwapper
+    );
     
 
     /**

--- a/contracts/ERC721Factory.sol
+++ b/contracts/ERC721Factory.sol
@@ -57,7 +57,10 @@ contract ERC721Factory is Deployer, Ownable {
     event TokenCreated(
         address indexed newTokenAddress,
         address indexed templateAddress,
-        string tokenName
+        string name,
+        string symbol,
+        uint256 cap,
+        address creator
     );  
     
     event NewPool(
@@ -326,7 +329,7 @@ contract ERC721Factory is Deployer, Ownable {
             token != address(0),
             "ERC721Factory: Failed to perform minimal deploy of a new token"
         );
-        emit TokenCreated(token, tokenTemplate.templateAddress, strings[0]);
+        emit TokenCreated(token, tokenTemplate.templateAddress, strings[0], strings[1], uints[0], owner);
         currentTokenCount += 1;
         tokenStruct memory tokenData; 
         tokenData.strings = strings;

--- a/contracts/ERC721Factory.sol
+++ b/contracts/ERC721Factory.sol
@@ -41,7 +41,7 @@ contract ERC721Factory is Deployer, Ownable {
     event NFTCreated(
         address indexed newTokenAddress,
         address indexed templateAddress,
-        string indexed tokenName,
+        string tokenName,
         address admin
     );
 
@@ -55,7 +55,7 @@ contract ERC721Factory is Deployer, Ownable {
     event TokenCreated(
         address indexed newTokenAddress,
         address indexed templateAddress,
-        string indexed tokenName
+        string tokenName
     );  
     
     event NewPool(

--- a/contracts/interfaces/IERC721Template.sol
+++ b/contracts/interfaces/IERC721Template.sol
@@ -190,7 +190,7 @@ interface IERC721Template is IERC165 {
         string calldata symbol,
         address erc20Factory,
         address additionalERC20Deployer,
-        string calldata baseURI
+        string calldata tokenURI
     ) external returns (bool);
 
     function hasRole(bytes32 role, address account)

--- a/contracts/pools/balancer/BPool.sol
+++ b/contracts/pools/balancer/BPool.sol
@@ -46,6 +46,15 @@ contract BPool is BMath, BToken {
         uint256 tokenAmountIn,
         uint256 timestamp
     );
+    event LOG_SETUP(
+        address indexed caller,
+        address indexed baseToken,
+        uint256 baseTokenAmountIn,
+        uint256 baseTokenWeight,
+        address indexed dataToken,
+        uint256 dataTokenAmountIn,
+        uint256 dataTokenWeight
+    );
 
     event LOG_EXIT(
         address indexed caller,
@@ -207,6 +216,9 @@ contract BPool is BMath, BToken {
         );
         // finalize
         finalize();
+        emit LOG_SETUP(msg.sender, baseTokenAddress, baseTokenAmount, baseTokenWeight,
+            dataTokenAddress, dataTokenAmount, dataTokenWeight
+        );
     }
 
     //Proxy contract functionality: end

--- a/contracts/pools/dispenser/Dispenser.sol
+++ b/contracts/pools/dispenser/Dispenser.sol
@@ -28,12 +28,10 @@ contract Dispenser {
         address indexed owner,
         uint256 maxTokens,
         uint256 maxBalance,
-        address allowedSwapper,
-        bool isMinter
+        address allowedSwapper
     );
     event DispenserActivated(  // emited when a dispenser is activated
-        address indexed datatokenAddress,
-        bool isMinter
+        address indexed datatokenAddress
     );
 
     event DispenserDeactivated( // emited when a dispenser is deactivated
@@ -47,8 +45,7 @@ contract Dispenser {
         // emited when tokens are dispended
         address indexed datatokenAddress,
         address indexed userAddress,
-        uint256 amount,
-        bool isMinter
+        uint256 amount
     );
 
     event OwnerWithdrawed(
@@ -122,8 +119,7 @@ contract Dispenser {
         datatokens[datatoken].maxBalance = maxBalance;
         datatokens[datatoken].allowedSwapper = allowedSwapper;
         datatokensList.push(datatoken);
-        emit DispenserCreated(datatoken, owner, maxTokens, maxBalance, allowedSwapper, 
-            IERC20Template(datatoken).isMinter(address(this)));
+        emit DispenserCreated(datatoken, owner, maxTokens, maxBalance, allowedSwapper);
         emit DispenserAllowedSwapperChanged(datatoken, allowedSwapper);
     }
     /**
@@ -146,7 +142,7 @@ contract Dispenser {
         datatokens[datatoken].maxTokens = maxTokens;
         datatokens[datatoken].maxBalance = maxBalance;
         datatokensList.push(datatoken);
-        emit DispenserActivated(datatoken, IERC20Template(datatoken).isMinter(address(this)));
+        emit DispenserActivated(datatoken);
     }
 
     /**
@@ -238,7 +234,7 @@ contract Dispenser {
             'Not enough reserves'
         );
         tokenInstance.transfer(destination,amount);
-        emit TokensDispensed(datatoken, destination, amount, IERC20Template(datatoken).isMinter(address(this)));
+        emit TokensDispensed(datatoken, destination, amount);
     }
 
     /**

--- a/contracts/pools/dispenser/Dispenser.sol
+++ b/contracts/pools/dispenser/Dispenser.sol
@@ -24,10 +24,16 @@ contract Dispenser {
     
     
     event DispenserCreated(  // emited when a dispenser is created
-        address indexed datatokenAddress
+        address indexed datatokenAddress,
+        address indexed owner,
+        uint256 maxTokens,
+        uint256 maxBalance,
+        address allowedSwapper,
+        bool isMinter
     );
     event DispenserActivated(  // emited when a dispenser is activated
-        address indexed datatokenAddress
+        address indexed datatokenAddress,
+        bool isMinter
     );
 
     event DispenserDeactivated( // emited when a dispenser is deactivated
@@ -41,7 +47,8 @@ contract Dispenser {
         // emited when tokens are dispended
         address indexed datatokenAddress,
         address indexed userAddress,
-        uint256 amount
+        uint256 amount,
+        bool isMinter
     );
 
     event OwnerWithdrawed(
@@ -115,7 +122,8 @@ contract Dispenser {
         datatokens[datatoken].maxBalance = maxBalance;
         datatokens[datatoken].allowedSwapper = allowedSwapper;
         datatokensList.push(datatoken);
-        emit DispenserCreated(datatoken);
+        emit DispenserCreated(datatoken, owner, maxTokens, maxBalance, allowedSwapper, 
+            IERC20Template(datatoken).isMinter(address(this)));
         emit DispenserAllowedSwapperChanged(datatoken, allowedSwapper);
     }
     /**
@@ -138,7 +146,7 @@ contract Dispenser {
         datatokens[datatoken].maxTokens = maxTokens;
         datatokens[datatoken].maxBalance = maxBalance;
         datatokensList.push(datatoken);
-        emit DispenserActivated(datatoken);
+        emit DispenserActivated(datatoken, IERC20Template(datatoken).isMinter(address(this)));
     }
 
     /**
@@ -230,7 +238,7 @@ contract Dispenser {
             'Not enough reserves'
         );
         tokenInstance.transfer(destination,amount);
-        emit TokensDispensed(datatoken, destination, amount);
+        emit TokensDispensed(datatoken, destination, amount, IERC20Template(datatoken).isMinter(address(this)));
     }
 
     /**

--- a/contracts/templates/ERC721Template.sol
+++ b/contracts/templates/ERC721Template.sol
@@ -184,7 +184,7 @@ contract ERC721Template is
             permissions[msg.sender].updateMetadata == true,
             "ERC721Template: NOT METADATA_ROLE"
         );
-        setMetaDataState(_metaDataState);
+        metaDataState = _metaDataState;
         metaDataDecryptorUrl = _metaDataDecryptorUrl;
         metaDataDecryptorAddress = _metaDataDecryptorAddress;
         if(hasMetaData == false){

--- a/contracts/templates/ERC721Template.sol
+++ b/contracts/templates/ERC721Template.sol
@@ -34,8 +34,11 @@ contract ERC721Template is
     event TokenCreated(
         address indexed newTokenAddress,
         address indexed templateAddress,
-        string tokenName
-    );
+        string name,
+        string symbol,
+        uint256 cap,
+        address creator
+    );  
     event MetadataCreated(
         address indexed createdBy,
         uint8 state,

--- a/contracts/templates/ERC721Template.sol
+++ b/contracts/templates/ERC721Template.sol
@@ -56,6 +56,13 @@ contract ERC721Template is
         uint256 timestamp,
         uint256 blockNumber
     );
+    event MetadataState(
+        address indexed updatedBy,
+        uint8 state,
+        uint256 timestamp,
+        uint256 blockNumber
+    );
+
     modifier onlyNFTOwner() {
         require(msg.sender == ownerOf(1), "ERC721Template: not NFTOwner");
         _;
@@ -143,6 +150,23 @@ contract ERC721Template is
     }
 
     /**
+     * @dev setMetaDataState
+     *      Updates metadata state
+     * @param _metaDataState metadata state
+     */
+    function setMetaDataState(uint8 _metaDataState) public {
+        require(
+            permissions[msg.sender].updateMetadata == true,
+            "ERC721Template: NOT METADATA_ROLE"
+        );
+        metaDataState = _metaDataState;
+        emit MetadataState(msg.sender, _metaDataState,
+            /* solium-disable-next-line */
+            block.timestamp,
+            block.number);
+    }
+
+    /**
      * @dev setMetaData
      *     
              Creates or update Metadata for Aqua(emit event)
@@ -160,7 +184,7 @@ contract ERC721Template is
             permissions[msg.sender].updateMetadata == true,
             "ERC721Template: NOT METADATA_ROLE"
         );
-        metaDataState = _metaDataState;
+        setMetaDataState(_metaDataState);
         metaDataDecryptorUrl = _metaDataDecryptorUrl;
         metaDataDecryptorAddress = _metaDataDecryptorAddress;
         if(hasMetaData == false){

--- a/contracts/templates/ERC721Template.sol
+++ b/contracts/templates/ERC721Template.sol
@@ -34,7 +34,7 @@ contract ERC721Template is
     event TokenCreated(
         address indexed newTokenAddress,
         address indexed templateAddress,
-        string indexed tokenName
+        string tokenName
     );
     event MetadataCreated(
         address indexed createdBy,

--- a/contracts/templates/ERC721Template.sol
+++ b/contracts/templates/ERC721Template.sol
@@ -63,6 +63,14 @@ contract ERC721Template is
         uint256 blockNumber
     );
 
+    event TokenURIUpdate(
+        address indexed updatedBy,
+        string tokenURI,
+        uint256 tokenID,
+        uint256 timestamp,
+        uint256 blockNumber
+    );
+
     modifier onlyNFTOwner() {
         require(msg.sender == ownerOf(1), "ERC721Template: not NFTOwner");
         _;
@@ -86,7 +94,7 @@ contract ERC721Template is
         string calldata symbol_,
         address tokenFactory,
         address additionalERC20Deployer,
-        string memory baseURI
+        string memory tokenURI
     ) external returns (bool) {
         require(
             !initialized,
@@ -98,7 +106,7 @@ contract ERC721Template is
                 name_,
                 symbol_,
                 tokenFactory,
-                baseURI
+                tokenURI
             );
         if(initResult && additionalERC20Deployer != address(0))
             _addToCreateERC20List(additionalERC20Deployer);
@@ -114,7 +122,7 @@ contract ERC721Template is
      * @param name_ NFT name
      * @param symbol_ NFT Symbol
      * @param tokenFactory NFT factory address
-     * @param baseURI base URI for NFT attributes
+     * @param tokenURI tokenURI for token 1
      
      @return boolean
      */
@@ -124,7 +132,7 @@ contract ERC721Template is
         string memory name_,
         string memory symbol_,
         address tokenFactory,
-        string memory baseURI
+        string memory tokenURI
     ) internal returns (bool) {
         require(
             owner != address(0),
@@ -134,7 +142,7 @@ contract ERC721Template is
         _name = name_;
         _symbol = symbol_;
         _tokenFactory = tokenFactory;
-        defaultBaseURI = baseURI;
+        defaultBaseURI = "";
         initialized = true;
         hasMetaData = false;
         _safeMint(owner, 1);
@@ -146,7 +154,23 @@ contract ERC721Template is
         user.deployERC20 = true;
         user.store = true;
         // no need to push to auth since it has been already added in _addManager()
+        _setTokenURI(1, tokenURI);
+        
         return initialized;
+    }
+
+    /**
+     * @dev setTokenURI
+     *      sets tokenURI for a tokenId
+     * @param tokenId token ID
+     * @param tokenURI token URI
+     */
+    function setTokenURI(uint256 tokenId, string memory tokenURI) external onlyNFTOwner {
+        _setTokenURI(tokenId, tokenURI);
+        emit TokenURIUpdate(msg.sender, tokenURI, tokenId,
+            /* solium-disable-next-line */
+            block.timestamp,
+            block.number);
     }
 
     /**

--- a/contracts/utils/ERC721/ERC721.sol
+++ b/contracts/utils/ERC721/ERC721.sol
@@ -36,6 +36,8 @@ contract ERC721 is Context, IERC721, IERC721Metadata {
     // Mapping from owner to operator approvals
     mapping (address => mapping (address => bool)) private _operatorApprovals;
 
+     // Optional mapping for token URIs
+    mapping (uint256 => string) private _tokenURIs;
     
     /**
      * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
@@ -76,16 +78,33 @@ contract ERC721 is Context, IERC721, IERC721Metadata {
         return _symbol;
     }
 
+     /**
+     * @dev Sets `_tokenURI` as the tokenURI of `tokenId`.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function _setTokenURI(uint256 tokenId, string memory _tokenURI) internal virtual {
+        require(_exists(tokenId), "ERC721URIStorage: URI set of nonexistent token");
+        _tokenURIs[tokenId] = _tokenURI;
+    }
+    
     /**
      * @dev See {IERC721Metadata-tokenURI}.
      */
     function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
         require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
+        string memory _tokenURI = _tokenURIs[tokenId];
+        string memory base = _baseURI();
 
-        string memory baseURI = _baseURI();
-        return bytes(baseURI).length > 0
-            ? string(abi.encodePacked(baseURI, tokenId.toString()))
-            : '';
+        // If both are set, concatenate the baseURI and tokenURI (via abi.encodePacked).
+        if (bytes(_tokenURI).length > 0) {
+            return string(abi.encodePacked(base, _tokenURI));
+        }
+        else{
+            return _tokenURI;
+        }
     }
 
     /**

--- a/test/unit/datatokens/ERC721Template.test.js
+++ b/test/unit/datatokens/ERC721Template.test.js
@@ -229,6 +229,14 @@ describe("ERC721Template", () => {
     );
   });
 
+  it("#updateMetadata - should not be allowed to update the metadata state if NOT in MetadataList", async () => {
+    assert((await tokenERC721.getPermissions(user6.address)).updateMetadata == false)
+    await expectRevert(
+      tokenERC721.connect(user6).setMetaDataState(metaDataState),
+      "ERC721Template: NOT METADATA_ROLE"
+    );
+  });
+
   it("#updateMetadata - should create & update the metadata, after adding address to MetadataList", async () => {
     assert((await tokenERC721.getPermissions(user6.address)).updateMetadata == false)
     await tokenERC721.addToMetadataList(user6.address);
@@ -258,6 +266,24 @@ describe("ERC721Template", () => {
     assert(metadataInfo[3] === true)
     assert(metadataInfo[0] == metaDataDecryptorUrl2);
 
+  });
+
+  it("#updateMetadata - should be able to update metadata state", async () => {
+    assert((await tokenERC721.getPermissions(user6.address)).updateMetadata == false)
+    await tokenERC721.addToMetadataList(user6.address);
+    let metadataInfo = await tokenERC721.getMetaData()
+    assert(metadataInfo[3] === false)
+
+    let tx = await tokenERC721.connect(user6).setMetaDataState(metaDataState);
+    let txReceipt = await tx.wait();
+   
+    let event = getEventFromTx(txReceipt,'MetadataState')
+    assert(event, "Cannot find MetadataState event")
+    assert(event.args[1] == metaDataState);
+    
+    metadataInfo = await tokenERC721.getMetaData()
+    assert(metadataInfo[2] === metaDataState)
+    
   });
 
   it("#createERC20 - should not allow to create a new ERC20Token if NOT in CreateERC20List", async () => {

--- a/test/unit/datatokens/ERC721Template.test.js
+++ b/test/unit/datatokens/ERC721Template.test.js
@@ -217,7 +217,7 @@ describe("ERC721Template", () => {
   });
 
   it("#tokenURI - should get proper tokenURI", async () => {
-    assert((await tokenERC721.tokenURI(1)) == "https://oceanprotocol.com/nft/1");
+    assert((await tokenERC721.tokenURI(1)) == "https://oceanprotocol.com/nft/");
   });
   
 
@@ -593,12 +593,27 @@ describe("ERC721Template", () => {
 
   it("#setBaseURI - should fail to update tokenURI if NOT NFT Owner", async () => {
     await expectRevert(tokenERC721.connect(user3).setBaseURI('https://newurl.com/nft/'),'ERC721Template: not NFTOwner')
-    assert((await tokenERC721.tokenURI(1)) == "https://oceanprotocol.com/nft/1");
+    const tokenURI= await tokenERC721.tokenURI(1)
+    assert(tokenURI == "https://oceanprotocol.com/nft/");
   });
 
 
   it("#setBaseURI - should update tokenURI if NFT Owner", async () => {
     await tokenERC721.setBaseURI('https://newurl.com/nft/')
-    assert((await tokenERC721.tokenURI(1)) == "https://newurl.com/nft/1");
+    const tokenURI= await tokenERC721.tokenURI(1)
+    assert(tokenURI == "https://newurl.com/nft/https://oceanprotocol.com/nft/", 'ERC721Template: TokenURI invalid');
+  });
+
+  it("#setTokenURI - should fail to update tokenURI if NOT NFT Owner", async () => {
+    await expectRevert(tokenERC721.connect(user3).setTokenURI(1,'https://anothernewurl.com/nft/'),'ERC721Template: not NFTOwner')
+    const tokenURI= await tokenERC721.tokenURI(1)
+    assert(tokenURI == "https://oceanprotocol.com/nft/");
+  });
+
+
+  it("#setTokenURI - should update tokenURI if NFT Owner", async () => {
+    await tokenERC721.setTokenURI(1,'https://anothernewurl.com/nft/')
+    const tokenURI= await tokenERC721.tokenURI(1)
+    assert(tokenURI == "https://anothernewurl.com/nft/");
   });
 });

--- a/test/unit/factories/ERC721Factory.test.js
+++ b/test/unit/factories/ERC721Factory.test.js
@@ -985,7 +985,7 @@ describe("ERC721Factory", () => {
       "name": "72120Bundle",
       "symbol": "72Bundle",
       "templateIndex": 1,
-      "baseURI":"https://oceanprotocol.com/nft/" 
+      "tokenURI":"https://oceanprotocol.com/nft/" 
 
       },
       {
@@ -1029,7 +1029,7 @@ describe("ERC721Factory", () => {
       "name": "72120PBundle",
       "symbol": "72PBundle",
       "templateIndex": 1,
-      "baseURI":"https://oceanprotocol.com/nft/"   
+      "tokenURI":"https://oceanprotocol.com/nft/"   
       },
       {
       "strings":["ERC20WithPool","ERC20P"],
@@ -1098,7 +1098,7 @@ describe("ERC721Factory", () => {
       "name": "72120PBundle",
       "symbol": "72PBundle",
       "templateIndex": 1, 
-      "baseURI":"https://oceanprotocol.com/nft/" 
+      "tokenURI":"https://oceanprotocol.com/nft/" 
       },
       {
       "strings":["ERC20WithPool","ERC20P"],
@@ -1150,7 +1150,7 @@ describe("ERC721Factory", () => {
       "name": "72120PBundle",
       "symbol": "72PBundle",
       "templateIndex": 1, 
-      "baseURI":"https://oceanprotocol.com/nft/" 
+      "tokenURI":"https://oceanprotocol.com/nft/" 
       },
       {
       "strings":["ERC20WithPool","ERC20P"],


### PR DESCRIPTION
Changes proposed in this PR:

- ERC721: add new function setMetaDataState   (allows publisher to change state using a cheap function)
- ERC721: added MetadataState event so Aquarius can track for state changes
- Remove all indexed strings in events  (a string should never be indexed in a event)
- Adding more details to some events (ERC721, Dispenser, ERC20)
- Proper use of tokenURI in ERC721


@mihaisc - do you need anything else for the graph?