### PR TITLE
Feature/predictoor iteration 2

### DIFF
--- a/contracts/interfaces/IFixedRateExchange.sol
+++ b/contracts/interfaces/IFixedRateExchange.sol
@@ -72,4 +72,5 @@ interface IFixedRateExchange {
     function getId() pure external returns (uint8);
     function collectBT(bytes32 exchangeId, uint256 amount) external;
     function collectDT(bytes32 exchangeId, uint256 amount) external;
+    function toggleExchangeState(bytes32 exchangeId) external;
 }

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -1089,6 +1089,13 @@ contract ERC20Template3 is
 
     function pausePredictions() external onlyERC20Deployer {
         paused = !paused;
+        if (fixedRateExchanges.length>0){
+            IFixedRateExchange fre = IFixedRateExchange(fixedRateExchanges[0].contractAddress);
+            bool freActive = fre.isActive(fixedRateExchanges[0].id);
+            if ((paused && freActive) || (!paused && !freActive)){
+                fre.toggleExchangeState(fixedRateExchanges[0].id);
+            }
+        }
         // TODO - pause FRE as well
     }
 

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -1109,7 +1109,6 @@ contract ERC20Template3 is
         uint256 floatValue,
         bool cancelRound
     ) external onlyERC20Deployer {
-        // TODO, is onlyERC20Deployer the right modifier?
         require(blocknum < block.number, "too early to submit");
         uint256 slot = railBlocknumToSlot(blocknum);
         require(epochStatus[slot]==Status.Pending, "already settled");

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -387,7 +387,7 @@ contract ERC20Template3 is
         require(addresses[2] != address(0),"FeeCollector cannot be zero");
         //force FRE allowedSwapper to this contract address. no one else can swap because we need to record the income
         if (uints[4] > 0) _addMinter(fixedPriceAddress);
-        addresses[1]=address(this); //make this contract FRE owner
+        // create the exchange
         exchangeId = IFactoryRouter(router).deployFixedRate(
             fixedPriceAddress,
             addresses,
@@ -1089,6 +1089,8 @@ contract ERC20Template3 is
 
     function pausePredictions() external onlyERC20Deployer {
         paused = !paused;
+        // we cannot pause FixedRate as well, so be aware when triggering this function
+        /* keeping code here until we decide
         if (fixedRateExchanges.length>0){
             IFixedRateExchange fre = IFixedRateExchange(fixedRateExchanges[0].contractAddress);
             bool freActive = fre.isActive(fixedRateExchanges[0].id);
@@ -1096,7 +1098,8 @@ contract ERC20Template3 is
                 fre.toggleExchangeState(fixedRateExchanges[0].id);
             }
         }
-        // TODO - pause FRE as well
+        */
+        
     }
 
     /**


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- add floatValue  to submitTrueVal, for better accuracy tracking
- allow owner to cancel an epoch by passing cancelRound = true in submitTrueVal
- make sure that feeCollector gets fixed rate fees, slashed stakes, revenue per epoch if no predictoors  (and not ERC20Deployer)
- handle edge case when all stakers are wrong and will be slashed  (feeCollector gets all stakes)

Tests:

- [x] Write test for edge case
- [x] Write test for "allow owner to cancel an epoch by passing cancelRound"