### PR TITLE
Hide stake amounts for prediction epoch & Allow predictoors modify their stake amount

### DIFF
--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -1004,7 +1004,7 @@ contract ERC20Template3 is
                 IERC20(stakeToken).safeTransferFrom(msg.sender, address(this), payment);
             } else if (stake < oldStake) {
                 uint256 refund = oldStake - stake;
-                IERC20(stakeToken).safeTransferFrom(address(this), msg.sender, payment);
+                IERC20(stakeToken).safeTransferFrom(address(this), msg.sender, refund);
             }
             require(predictions[epoch_start][msg.sender].stake == stake, "cannot modify stake amt");
             predictions[epoch_start][msg.sender].predictedValue = predictedValue;

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -1007,6 +1007,7 @@ contract ERC20Template3 is
         emit PredictionSubmitted(msg.sender, epoch_start, stake);
         if (submittedPredval(epoch_start, msg.sender)) {
             uint256 oldStake = predictions[epoch_start][msg.sender].stake;
+            predictions[epoch_start][msg.sender].stake = 0; // Reentrancy precaution
             if (stake > oldStake) {
                 uint256 payment = stake - oldStake;
                 IERC20(stakeToken).safeTransferFrom(msg.sender, address(this), payment);

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -967,6 +967,7 @@ contract ERC20Template3 is
         uint256 epoch_start
     ) public view returns (uint256, uint256) {
         require(toEpochStart(epoch_start) == epoch_start, "invalid epoch");
+        require(soonestEpochToPredict(curEpoch()) > epoch_start, "predictions not closed");
         return roundSumStakesUp[epoch_start] + roundSumStakes[epoch_start];
     }
 

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -951,6 +951,7 @@ contract ERC20Template3 is
         bytes32 s; // s of provider signed message
         uint256 validUntil; 
     }
+
     function getAggPredval(
         uint256 epoch_start,
         userAuth calldata _userAuth
@@ -960,6 +961,13 @@ contract ERC20Template3 is
         require(toEpochStart(epoch_start) == epoch_start, "invalid epoch");
         require(soonestEpochToPredict(curEpoch()) > epoch_start, "predictions not closed");
         return (roundSumStakesUp[epoch_start], roundSumStakes[epoch_start]);
+    }
+
+    function getTotalStake(
+        uint256 epoch_start
+    ) public view returns (uint256, uint256) {
+        require(toEpochStart(epoch_start) == epoch_start, "invalid epoch");
+        return roundSumStakesUp[epoch_start] + roundSumStakes[epoch_start];
     }
 
     function getsubscriptionRevenueAtEpoch(

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -1013,7 +1013,7 @@ contract ERC20Template3 is
                 IERC20(stakeToken).safeTransferFrom(msg.sender, address(this), payment);
             } else if (stake < oldStake) {
                 uint256 refund = oldStake - stake;
-                IERC20(stakeToken).safeTransferFrom(address(this), msg.sender, refund);
+                IERC20(stakeToken).transfer(msg.sender, refund);
             }
             predictions[epoch_start][msg.sender].predictedValue = predictedValue;
             predictions[epoch_start][msg.sender].stake = stake;

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -958,7 +958,7 @@ contract ERC20Template3 is
         _checkUserAuthorization(_userAuth);
         require(isValidSubscription(_userAuth.userAddress), "No subscription");
         require(toEpochStart(epoch_start) == epoch_start, "invalid epoch");
-        require(soonestEpochToPredict(epoch_start) != epoch_start, "predictions not closed")
+        require(soonestEpochToPredict(block.timestamp) < epoch_start, "predictions not closed")
         return (roundSumStakesUp[epoch_start], roundSumStakes[epoch_start]);
     }
 

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -958,7 +958,7 @@ contract ERC20Template3 is
         _checkUserAuthorization(_userAuth);
         require(isValidSubscription(_userAuth.userAddress), "No subscription");
         require(toEpochStart(epoch_start) == epoch_start, "invalid epoch");
-        require(soonestEpochToPredict(block.timestamp) < epoch_start, "predictions not closed")
+        require(soonestEpochToPredict(curEpoch()) < epoch_start, "predictions not closed")
         return (roundSumStakesUp[epoch_start], roundSumStakes[epoch_start]);
     }
 

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -1015,7 +1015,6 @@ contract ERC20Template3 is
                 uint256 refund = oldStake - stake;
                 IERC20(stakeToken).safeTransferFrom(address(this), msg.sender, refund);
             }
-            require(predictions[epoch_start][msg.sender].stake == stake, "cannot modify stake amt");
             predictions[epoch_start][msg.sender].predictedValue = predictedValue;
             predictions[epoch_start][msg.sender].stake = stake;
             return;

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -958,7 +958,7 @@ contract ERC20Template3 is
         _checkUserAuthorization(_userAuth);
         require(isValidSubscription(_userAuth.userAddress), "No subscription");
         require(toEpochStart(epoch_start) == epoch_start, "invalid epoch");
-        require(soonestEpochToPredict(curEpoch()) < epoch_start, "predictions not closed")
+        require(soonestEpochToPredict(curEpoch()) > epoch_start, "predictions not closed")
         return (roundSumStakesUp[epoch_start], roundSumStakes[epoch_start]);
     }
 

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -968,7 +968,7 @@ contract ERC20Template3 is
     ) public view returns uint256 {
         require(toEpochStart(epoch_start) == epoch_start, "invalid epoch");
         require(soonestEpochToPredict(curEpoch()) > epoch_start, "predictions not closed");
-        return roundSumStakesUp[epoch_start] + roundSumStakes[epoch_start];
+        return roundSumStakes[epoch_start];
     }
 
     function getsubscriptionRevenueAtEpoch(

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -15,7 +15,6 @@ import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "../utils/ERC20Roles.sol";
-
 /**
  * @title DatatokenTemplate
  *
@@ -1181,6 +1180,7 @@ contract ERC20Template3 is
         uint256 s_per_subscription,
         uint256 _truval_submit_timeout
     ) internal {
+        require(s_per_subscription % s_per_epoch == 0, "%");
         if (secondsPerEpoch == 0) {
             secondsPerEpoch = s_per_epoch;
         }

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -958,7 +958,7 @@ contract ERC20Template3 is
         _checkUserAuthorization(_userAuth);
         require(isValidSubscription(_userAuth.userAddress), "No subscription");
         require(toEpochStart(epoch_start) == epoch_start, "invalid epoch");
-        require(soonestEpochToPredict(curEpoch()) > epoch_start, "predictions not closed")
+        require(soonestEpochToPredict(curEpoch()) > epoch_start, "predictions not closed");
         return (roundSumStakesUp[epoch_start], roundSumStakes[epoch_start]);
     }
 

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -965,7 +965,7 @@ contract ERC20Template3 is
 
     function getTotalStake(
         uint256 epoch_start
-    ) public view returns (uint256, uint256) {
+    ) public view returns uint256 {
         require(toEpochStart(epoch_start) == epoch_start, "invalid epoch");
         require(soonestEpochToPredict(curEpoch()) > epoch_start, "predictions not closed");
         return roundSumStakesUp[epoch_start] + roundSumStakes[epoch_start];

--- a/contracts/templates/ERC20Template3.sol
+++ b/contracts/templates/ERC20Template3.sol
@@ -965,7 +965,7 @@ contract ERC20Template3 is
 
     function getTotalStake(
         uint256 epoch_start
-    ) public view returns uint256 {
+    ) public view returns (uint256) {
         require(toEpochStart(epoch_start) == epoch_start, "invalid epoch");
         require(soonestEpochToPredict(curEpoch()) > epoch_start, "predictions not closed");
         return roundSumStakes[epoch_start];

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -1191,7 +1191,10 @@ describe("ERC20Template3", () => {
 
         let soonestEpochToPredict = await erc20Token.soonestEpochToPredict(await blocktimestamp());
         const userAuth = await authorize(user2.address)
-        const [numer, denom] = await erc20Token.connect(user2).getAggPredval(soonestEpochToPredict, userAuth);
+        await expectRevert(erc20Token.connect(user2).getAggPredval(soonestEpochToPredict, userAuth), "predictions not closed");
+        
+        let curEpoch = await erc20Token.curEpoch();
+        const [numer, denom] = await erc20Token.connect(user2).getAggPredval(curEpoch, userAuth);
         expect(numer).to.be.eq(0);
         expect(denom).to.be.eq(0);
 
@@ -1201,7 +1204,9 @@ describe("ERC20Template3", () => {
         await mockErc20.transfer(user3.address, stake);
         await mockErc20.connect(user3).approve(erc20Token.address, stake);
         await erc20Token.connect(user3).submitPredval(predictedValue, stake, soonestEpochToPredict);
-
+        
+        fastForward(secondsPerEpoch)
+        let curEpoch = await erc20Token.curEpoch();
         const [numer2, denom2] = await erc20Token.connect(user2).getAggPredval(soonestEpochToPredict, userAuth);
         expect(numer2).to.be.eq(web3.utils.toWei("1"));
         expect(denom2).to.be.eq(web3.utils.toWei("1"));

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -1193,11 +1193,14 @@ describe("ERC20Template3", () => {
         let soonestEpochToPredict = await erc20Token.soonestEpochToPredict(await blocktimestamp());
         const userAuth = await authorize(user2.address)
         await expectRevert(erc20Token.connect(user2).getAggPredval(soonestEpochToPredict, userAuth), "predictions not closed");
+        await expectRevert(erc20Token.getTotalStake(soonestEpochToPredict), "predictions not closed");
         
         let curEpoch = await erc20Token.curEpoch();
         const [numer, denom] = await erc20Token.connect(user2).getAggPredval(curEpoch, userAuth);
+        const totalStake = await erc20Token.getTotalStake(curEpoch);
         expect(numer).to.be.eq(0);
         expect(denom).to.be.eq(0);
+        expect(totalStake).to.be.eq(0);
 
         // user2 makes a prediction
         const predictedValue = true;
@@ -1210,8 +1213,10 @@ describe("ERC20Template3", () => {
         await fastForward(secondsPerEpoch)
         curEpoch = await erc20Token.curEpoch();
         const [numer2, denom2] = await erc20Token.connect(user2).getAggPredval(curEpoch + secondsPerEpoch, userAuth);
+        const totalStake2 = await erc20Token.getTotalStake(curEpoch);
         expect(numer2).to.be.eq(web3.utils.toWei("1"));
         expect(denom2).to.be.eq(web3.utils.toWei("1"));
+        expect(totalStake2).to.be.eq(web3.utils.toWei("1"));
 
         // check subscription revenue
         const revenue = await erc20Token.getsubscriptionRevenueAtEpoch(soonestEpochToPredict);

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -849,12 +849,12 @@ describe("ERC20Template3", () => {
         let mockErc20BalanceBefore = await mockErc20.balanceOf(owner.address);
         await erc20Token.submitPredval(predictedValue, stake + 1, soonestEpochToPredict);
         let mockErc20BalanceAfter = await mockErc20.balanceOf(owner.address);
-        expect(mockErc20BalanceAfter).to.equal(mockErc20BalanceBefore.add(-1))
+        expect(mockErc20BalanceBefore).to.equal(mockErc20BalanceAfter.add(1))
 
         mockErc20BalanceBefore = await mockErc20.balanceOf(owner.address);
         await erc20Token.submitPredval(predictedValue, stake - 1, soonestEpochToPredict),
         mockErc20BalanceAfter = await mockErc20.balanceOf(owner.address);
-        expect(mockErc20BalanceAfter).to.equal(mockErc20BalanceBefore.add(1))
+        expect(mockErc20BalanceAfter).to.equal(mockErc20BalanceBefore.add(2))
     });
     it("#pausePredictions - should pause and resume predictions", async () => {
         await erc20Token.pausePredictions();

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -1210,7 +1210,7 @@ describe("ERC20Template3", () => {
         await erc20Token.connect(user3).submitPredval(predictedValue, stake, soonestEpochToPredict);
         
         const secondsPerEpoch = await erc20Token.secondsPerEpoch();
-        await fastForward(secondsPerEpoch)
+        await fastForward(secondsPerEpoch.toNumber())
         curEpoch = await erc20Token.curEpoch();
         const [numer2, denom2] = await erc20Token.connect(user2).getAggPredval(curEpoch + secondsPerEpoch, userAuth);
         const totalStake2 = await erc20Token.getTotalStake(curEpoch);

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -23,7 +23,7 @@ const fastForward = async (seconds) => {
     await ethers.provider.send("evm_mine");
 }
 
-const sPerEpoch = 288;
+const sPerEpoch = 300;
 const sPerSubscription = 24 * 60 * 60;
 const trueValueSubmitTimeout = 24 * 60 * 60 * 3;
 

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -1207,7 +1207,7 @@ describe("ERC20Template3", () => {
         await erc20Token.connect(user3).submitPredval(predictedValue, stake, soonestEpochToPredict);
         
         const secondsPerEpoch = await erc20Token.secondsPerEpoch();
-        fastForward(secondsPerEpoch)
+        await fastForward(secondsPerEpoch)
         curEpoch = await erc20Token.curEpoch();
         const [numer2, denom2] = await erc20Token.connect(user2).getAggPredval(curEpoch + secondsPerEpoch, userAuth);
         expect(numer2).to.be.eq(web3.utils.toWei("1"));

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -700,6 +700,13 @@ describe("ERC20Template3", () => {
     });
 
     // PREDICTOOR
+    it("#toEpochStart - Should return the start of the epoch for a given timestamp", async function() {
+        const testTimestamp = 1691374249
+        const secondsPerEpoch = await erc20Token.secondsPerEpoch()
+        const expectedEpochStart = Math.floor(testTimestamp / secondsPerEpoch) * secondsPerEpoch;
+        const result = await erc20Token.toEpochStart(testTimestamp);
+        expect(result.toNumber()).to.equal(expectedEpochStart);
+    });
     it("#secondsPerEpoch - secondsPerEpoch should be set", async () => {
         const secondsPerEpoch = await erc20Token.secondsPerEpoch();
         assert(secondsPerEpoch > 0, 'Invalid secondsPerEpoch');

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -1205,6 +1205,7 @@ describe("ERC20Template3", () => {
         await mockErc20.connect(user3).approve(erc20Token.address, stake);
         await erc20Token.connect(user3).submitPredval(predictedValue, stake, soonestEpochToPredict);
         
+        const secondsPerEpoch = await erc20Token.secondsPerEpoch();
         fastForward(secondsPerEpoch)
         curEpoch = await erc20Token.curEpoch();
         const [numer2, denom2] = await erc20Token.connect(user2).getAggPredval(soonestEpochToPredict, userAuth);

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -845,6 +845,7 @@ describe("ERC20Template3", () => {
         prediction = await erc20Token.getPrediction(soonestEpochToPredict, owner.address, userAuth);
         expect(prediction.predictedValue).to.be.eq(!predictedValue);
 
+        await mockErc20.approve(erc20Token.address, 1);
         let mockErc20BalanceBefore = await mockErc20.balanceOf(owner.address);
         await erc20Token.submitPredval(predictedValue, stake + 1, soonestEpochToPredict);
         let mockErc20BalanceAfter = await mockErc20.balanceOf(owner.address);

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -1209,7 +1209,7 @@ describe("ERC20Template3", () => {
         const secondsPerEpoch = await erc20Token.secondsPerEpoch();
         fastForward(secondsPerEpoch)
         curEpoch = await erc20Token.curEpoch();
-        const [numer2, denom2] = await erc20Token.connect(user2).getAggPredval(curEpoch, userAuth);
+        const [numer2, denom2] = await erc20Token.connect(user2).getAggPredval(curEpoch + secondsPerEpoch, userAuth);
         expect(numer2).to.be.eq(web3.utils.toWei("1"));
         expect(denom2).to.be.eq(web3.utils.toWei("1"));
 

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -1209,7 +1209,7 @@ describe("ERC20Template3", () => {
         const secondsPerEpoch = await erc20Token.secondsPerEpoch();
         fastForward(secondsPerEpoch)
         curEpoch = await erc20Token.curEpoch();
-        const [numer2, denom2] = await erc20Token.connect(user2).getAggPredval(soonestEpochToPredict, userAuth);
+        const [numer2, denom2] = await erc20Token.connect(user2).getAggPredval(curEpoch, userAuth);
         expect(numer2).to.be.eq(web3.utils.toWei("1"));
         expect(denom2).to.be.eq(web3.utils.toWei("1"));
 

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -845,15 +845,15 @@ describe("ERC20Template3", () => {
         prediction = await erc20Token.getPrediction(soonestEpochToPredict, owner.address, userAuth);
         expect(prediction.predictedValue).to.be.eq(!predictedValue);
 
-        await expectRevert(
-            erc20Token.submitPredval(predictedValue, stake + 1, soonestEpochToPredict),
-            "cannot modify stake"
-        );
+        let mockErc20BalanceBefore = await mockErc20.balanceOf(owner.address);
+        await erc20Token.submitPredval(predictedValue, stake + 1, soonestEpochToPredict);
+        let mockErc20BalanceAfter = await mockErc20.balanceOf(owner.address);
+        expect(mockErc20BalanceAfter).to.equal(mockErc20BalanceBefore.add(-1))
 
-        await expectRevert(
-            erc20Token.submitPredval(predictedValue, stake - 1, soonestEpochToPredict),
-            "cannot modify stake"
-        );
+        mockErc20BalanceBefore = await mockErc20.balanceOf(owner.address);
+        await erc20Token.submitPredval(predictedValue, stake - 1, soonestEpochToPredict),
+        mockErc20BalanceAfter = await mockErc20.balanceOf(owner.address);
+        expect(mockErc20BalanceAfter).to.equal(mockErc20BalanceBefore.add(1))
     });
     it("#pausePredictions - should pause and resume predictions", async () => {
         await erc20Token.pausePredictions();

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -1349,7 +1349,9 @@ describe("ERC20Template3", () => {
         const balAfter = await mockErc20.balanceOf(user3.address);
         expect(balAfter).to.be.gt(balBefore);
         const profit = balAfter.sub(balBefore);
-        const expectedProfit = 1 + (2 / parseInt(3600 / parseInt(300 / 24)))
+        const secondsPerEpoch = await erc20Token.secondsPerEpoch();
+        const secondsPerSubscription = await erc20Token.secondsPerSubscription();
+        const expectedProfit = 1 + (2 / secondsPerSubscription * secondsPerEpoch)
         expect(parseFloat(web3.utils.fromWei(profit.toString()))).to.be.eq(expectedProfit);
 
         // user tries to call payout for the same slot
@@ -1478,7 +1480,9 @@ describe("ERC20Template3", () => {
         expect(balAfter).to.be.gt(balBefore);
 
         const profit = balAfter.sub(balBefore);
-        const expectedProfit = 1 + (2 / parseInt(3600 / parseInt(300 / 24)))
+        const secondsPerEpoch = await erc20Token.secondsPerEpoch();
+        const secondsPerSubscription = await erc20Token.secondsPerSubscription();
+        const expectedProfit = 1 + (2 / secondsPerSubscription * secondsPerEpoch);
         expect(parseFloat(web3.utils.fromWei(profit.toString()))).to.be.eq(expectedProfit);
 
         mockErc20Balance = await mockErc20.balanceOf(user3.address)
@@ -1634,7 +1638,7 @@ describe("ERC20Template3", () => {
         let event_2 = getEventFromTx(txReceipt_2, 'Transfer')
         expect(event_2.args.from).to.be.eq(erc20Token.address);
         expect(event_2.args.to).to.be.eq(freMarketFeeCollector.address);
-        expect(event_2.args.value).to.be.eq(6666666666666666);
+        expect(event_2.args.value).to.be.eq(revenue_at_block);
     })
     it("#redeemUnusedSlotRevenue - admin should not be able to redeem for future epoch", async () => {
         const secondsPerEpoch = await erc20Token.secondsPerEpoch();

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -1203,8 +1203,10 @@ describe("ERC20Template3", () => {
         await expectRevert(erc20Token.getTotalStake(soonestEpochToPredict), "predictions not closed");
         
         let curEpoch = await erc20Token.curEpoch();
-        const [numer, denom] = await erc20Token.connect(user2).getAggPredval(curEpoch, userAuth);
-        const totalStake = await erc20Token.getTotalStake(curEpoch);
+        const secondsPerEpoch = await erc20Token.secondsPerEpoch();
+        let predictedEpoch = curEpoch.add(secondsPerEpoch);
+        const [numer, denom] = await erc20Token.connect(user2).getAggPredval(predictedEpoch, userAuth);
+        const totalStake = await erc20Token.getTotalStake(predictedEpoch);
         expect(numer).to.be.eq(0);
         expect(denom).to.be.eq(0);
         expect(totalStake).to.be.eq(0);
@@ -1216,11 +1218,11 @@ describe("ERC20Template3", () => {
         await mockErc20.connect(user3).approve(erc20Token.address, stake);
         await erc20Token.connect(user3).submitPredval(predictedValue, stake, soonestEpochToPredict);
         
-        const secondsPerEpoch = await erc20Token.secondsPerEpoch();
         await fastForward(secondsPerEpoch.toNumber())
         curEpoch = await erc20Token.curEpoch();
-        const [numer2, denom2] = await erc20Token.connect(user2).getAggPredval(curEpoch + secondsPerEpoch, userAuth);
-        const totalStake2 = await erc20Token.getTotalStake(curEpoch);
+        predictedEpoch = curEpoch.add(secondsPerEpoch);
+        const [numer2, denom2] = await erc20Token.connect(user2).getAggPredval(predictedEpoch, userAuth);
+        const totalStake2 = await erc20Token.getTotalStake(predictedEpoch);
         expect(numer2).to.be.eq(web3.utils.toWei("1"));
         expect(denom2).to.be.eq(web3.utils.toWei("1"));
         expect(totalStake2).to.be.eq(web3.utils.toWei("1"));

--- a/test/unit/datatokens/ERC20Template3.test.js
+++ b/test/unit/datatokens/ERC20Template3.test.js
@@ -1206,7 +1206,7 @@ describe("ERC20Template3", () => {
         await erc20Token.connect(user3).submitPredval(predictedValue, stake, soonestEpochToPredict);
         
         fastForward(secondsPerEpoch)
-        let curEpoch = await erc20Token.curEpoch();
+        curEpoch = await erc20Token.curEpoch();
         const [numer2, denom2] = await erc20Token.connect(user2).getAggPredval(soonestEpochToPredict, userAuth);
         expect(numer2).to.be.eq(web3.utils.toWei("1"));
         expect(denom2).to.be.eq(web3.utils.toWei("1"));


### PR DESCRIPTION
Fixes #793

Changes proposed in this PR:

- Hide stake amounts for prediction epoch
- Allow predictoors modify their stake amount
- Adds a new view function "getTotalStake": returns the total amount of tokens staked for a given epoch, reverts if predicitons are **not** closed.
- Set seconds per epoch to 300 in the test.
- Remove hardcoded values from tests.
- Require seconds per subscription % seconds per epoch to be always 0.