### PR TITLE
check if basetoken is contract

### DIFF
--- a/contracts/pools/fixedRate/FixedRateExchange.sol
+++ b/contracts/pools/fixedRate/FixedRateExchange.sol
@@ -180,7 +180,18 @@ contract FixedRateExchange is ReentrancyGuard, IFixedRateExchange {
         return IFactoryRouter(router).getOPCFee(baseTokenAddress);
     }
   
-
+    /**
+     * @dev isContract
+     *      checks if address is a contract 
+     * addr  - address to be checked
+     */
+    function isContract(address addr) public view returns(bool){
+      uint32 size;
+      assembly {
+        size := extcodesize(addr)
+      }
+      return (size > 0);
+    }
     /**
      * @dev create
      *      creates new exchange pairs between a baseToken
@@ -208,6 +219,10 @@ contract FixedRateExchange is ReentrancyGuard, IFixedRateExchange {
         require(
             addresses[0] != address(0),
             "FixedRateExchange: Invalid baseToken,  zero address"
+        );
+        require(
+            isContract(addresses[0]),
+            "FixedRateExchange: Invalid baseToken, looks EOA"
         );
         require(
             datatoken != address(0),

--- a/test/flow/FixedRateExchange.test.js
+++ b/test/flow/FixedRateExchange.test.js
@@ -204,6 +204,15 @@ describe("FixedRateExchange", () => {
       mockDT18 = erc20Token;
     });
 
+    it("should fail if basetoken is EOA", async () => {
+      await expectRevert(mockDT18.connect(alice)
+      .createFixedRate(
+        fixedRateExchange.address,
+        [bob.address, alice.address, marketFeeCollector.address, ZERO_ADDRESS],
+        [18, 18, rate, marketFee, 0])
+      ,"FixedRateExchange: Invalid baseToken, looks EOA" )
+      
+    });
     it("#2 - create exchange", async () => {
       marketFee = 1e15;
 


### PR DESCRIPTION
Closes #718

Since there is no guaranteed way of telling if an adress is ERC20, let's make sure at least that is an existing contract.
Changes proposed in this PR:

- when fixed rate is created, check if basetoken address is a contract
- 
- 