### PR TITLE
deploy vestings B + C

### DIFF
--- a/addresses/address.json
+++ b/addresses/address.json
@@ -141,8 +141,8 @@
     "Distribute": "0x01BE353d9Fd3A64C591A30A8c4a6a37B5dfAe165",
     "VestingWallet0": "0x8D011915C437AD5f5e3B0E4c6dd6380c92599f99",
     "VestingWalletA": "0xf9FB1f54eA825734E3a77e73A3864f4B46C815d9",
-    "VestingWalletB": "0x8a8Ec65F257072e30Dd8FeF539dC6aD67d578074",
-    "VestingWalletC": "0xe2F2Abdf25D2ECc75E21691Ee8fF9c85737Faa37"
+    "VestingWalletB": "0xf02e3163Dc3409D69D88D7AcDA613432E9A18741",
+    "VestingWalletC": "0x29F74B853C4B8D36273666FB63a3b71c754424Ed"
   },
   "goerli": {
     "chainId": 5,

--- a/addresses/address.json
+++ b/addresses/address.json
@@ -140,7 +140,9 @@
     "Splitter": "0xadF0D06e58E618de36Af0F1b52891b14FAA61187",
     "Distribute": "0x01BE353d9Fd3A64C591A30A8c4a6a37B5dfAe165",
     "VestingWallet0": "0x8D011915C437AD5f5e3B0E4c6dd6380c92599f99",
-    "VestingWalletA": "0xf9FB1f54eA825734E3a77e73A3864f4B46C815d9"
+    "VestingWalletA": "0xf9FB1f54eA825734E3a77e73A3864f4B46C815d9",
+    "VestingWalletB": "0x8a8Ec65F257072e30Dd8FeF539dC6aD67d578074",
+    "VestingWalletC": "0xe2F2Abdf25D2ECc75E21691Ee8fF9c85737Faa37"
   },
   "goerli": {
     "chainId": 5,

--- a/scripts/deploy_vesting.js
+++ b/scripts/deploy_vesting.js
@@ -49,6 +49,7 @@ async function main() {
       OPFOwner = "0x0d27cd67c4A3fd3Eb9C7C757582f59089F058167";
       routerOwner = OPFOwner;
       OceanTokenAddress = "0x967da4048cD07aB37855c090aAF366e4ce1b9F48";
+      gasPrice = ethers.utils.parseUnits('16', 'gwei')
       break;
 
     default:
@@ -100,12 +101,21 @@ async function main() {
     const blockTimestamp = block.timestamp
     const endDate = "2024-03-14"
     const endDateUnix = parseInt(new Date(endDate).getTime() / 1000)
-    const startTimestamp = 1705017600  // Fri Jan 12 2024 00:00:00 GMT+0000
-    const endTimestamp = 1709856000 // Fri Mar 08 2024 00:00:00 GMT+0000   - this is when we top up last week of DF Main1
+    //vesting A
+    //const startTimestamp = 1705017600  // Fri Jan 12 2024 00:00:00 GMT+0000
+    //const endTimestamp = 1709856000 // Fri Mar 08 2024 00:00:00 GMT+0000   - this is when we top up last week of DF Main1
+    //vesting B
+    //const startTimestamp = 1710028800  // Sun Mar 10 2024 00:00:00 GMT+0000
+    //const endTimestamp = 1725750000 // Sat Sep 07 2024 23:00:00 GMT+0000   - this is when we top up last week of DF Main2
+    //vesting C
+    const startTimestamp = 1725750000  // Sat Sep 07 2024 23:00:00 GMT+0000
+    const endTimestamp = 1741392000 // Sat Mar 08 2025 00:00:00 GMT+0000   - this is when we top up last week of DF Main3
+    
+
     const vestingPeriod = endTimestamp - startTimestamp
     const deployVestingWallet0 = await VestingWallet0.connect(owner).deploy(addresses.Splitter, startTimestamp, vestingPeriod, options)
     await deployVestingWallet0.deployTransaction.wait();
-    addresses.VestingWalletA = deployVestingWallet0.address;
+    addresses.VestingWalletC = deployVestingWallet0.address;
     if (show_verify) {
       console.log("\tRun the following to verify on etherscan");
       console.log("\tnpx hardhat verify --network " + networkName + " " + addresses.VestingWalletA+" "+addresses.Splitter+" "+blockTimestamp+" "+vestingPeriod)

--- a/scripts/deploy_vesting.js
+++ b/scripts/deploy_vesting.js
@@ -49,7 +49,7 @@ async function main() {
       OPFOwner = "0x0d27cd67c4A3fd3Eb9C7C757582f59089F058167";
       routerOwner = OPFOwner;
       OceanTokenAddress = "0x967da4048cD07aB37855c090aAF366e4ce1b9F48";
-      gasPrice = ethers.utils.parseUnits('16', 'gwei')
+      gasPrice = ethers.utils.parseUnits('23', 'gwei')
       break;
 
     default:
@@ -106,10 +106,10 @@ async function main() {
     //const endTimestamp = 1709856000 // Fri Mar 08 2024 00:00:00 GMT+0000   - this is when we top up last week of DF Main1
     //vesting B
     //const startTimestamp = 1710028800  // Sun Mar 10 2024 00:00:00 GMT+0000
-    //const endTimestamp = 1725750000 // Sat Sep 07 2024 23:00:00 GMT+0000   - this is when we top up last week of DF Main2
+    //const endTimestamp = 1725753600 // Sun Sep 08 2024 00:00:00 GMT+0000   - this is when we top up last week of DF Main2
     //vesting C
-    const startTimestamp = 1725750000  // Sat Sep 07 2024 23:00:00 GMT+0000
-    const endTimestamp = 1741392000 // Sat Mar 08 2025 00:00:00 GMT+0000   - this is when we top up last week of DF Main3
+    const startTimestamp = 1725753600  // Sun Sep 08 2024 00:00:00 GMT+0000
+    const endTimestamp = 1741478400 // Sun Mar 09 2025 00:00:00 GMT+0000   - this is when we top up last week of DF Main3
     
 
     const vestingPeriod = endTimestamp - startTimestamp
@@ -118,7 +118,7 @@ async function main() {
     addresses.VestingWalletC = deployVestingWallet0.address;
     if (show_verify) {
       console.log("\tRun the following to verify on etherscan");
-      console.log("\tnpx hardhat verify --network " + networkName + " " + addresses.VestingWalletA+" "+addresses.Splitter+" "+blockTimestamp+" "+vestingPeriod)
+      console.log("\tnpx hardhat verify --network " + networkName + " " + deployVestingWallet0.address+" "+addresses.Splitter+" "+blockTimestamp+" "+vestingPeriod)
     }
     if (sleepAmount > 0) await sleep(sleepAmount)
     


### PR DESCRIPTION
Deployed vesting B + C

Vesting B:
- startTimestamp = 1710028800  // Sun Mar 10 2024 00:00:00 GMT+0000
- endTimestamp = 1725750000 // Sat Sep 07 2024 23:00:00 GMT+0000
- contract:  [0x8a8ec65f257072e30dd8fef539dc6ad67d578074](https://etherscan.io/address/0x8a8ec65f257072e30dd8fef539dc6ad67d578074)
- first vesting trigger:   Sun Mar 17 2024 00:00:00 GMT+0000

Vesting C:
- startTimestamp = 1725750000  // Sat Sep 07 2024 23:00:00 GMT+0000
- endTimestamp = 1741392000 // Sat Mar 08 2025 00:00:00 GMT+0000   - this is when we top up last week of DF Main3
- contract:  [0xe2f2abdf25d2ecc75e21691ee8ff9c85737faa37](https://etherscan.io/address/0xe2f2abdf25d2ecc75e21691ee8ff9c85737faa37)
- first vesting trigger:   Sat Sep 14 2024 23:00:00 GMT+0000


PS: Vestings will be triggered every Sunday, at 00:00, to save gas fees.